### PR TITLE
feat: show project list on nav hover

### DIFF
--- a/css/nav.css
+++ b/css/nav.css
@@ -51,6 +51,7 @@ body {
   /* 75% */
   margin: auto 10px;
   /* 50% */
+  font-size: 37.5px;
 }
 
 .nav a:hover {

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -1,31 +1,54 @@
-// JavaScript for Dropdown
+// JavaScript for hover-based dropdown navigation
 
 document.addEventListener('DOMContentLoaded', () => {
-    const dropdownToggles = document.querySelectorAll('.dropdown-toggle');
-    const dropdownFilm = document.querySelector('.dropdown_film');
-    const dropdownDigital = document.querySelector('.dropdown_digital');
+  const filmLink = document.querySelector('.dropdown-toggle.film');
+  const digitalLink = document.querySelector('.dropdown-toggle.digital');
+  const filmDropdown = document.querySelector('.dropdown_film');
+  const digitalDropdown = document.querySelector('.dropdown_digital');
 
-    dropdownToggles.forEach(toggle => {
-        toggle.addEventListener('click', (e) => {
-            e.preventDefault();
-            const clickedDropdown = toggle.textContent.toLowerCase();
+  function show(dropdown) {
+    dropdown.style.display = 'block';
+  }
 
-            if (clickedDropdown === 'film') {
-                dropdownFilm.style.display = dropdownFilm.style.display === 'block' ? 'none' :
-                    'block';
-                dropdownDigital.style.display = 'none';
-            } else if (clickedDropdown === 'digital') {
-                dropdownDigital.style.display = dropdownDigital.style.display === 'block' ?
-                    'none' : 'block';
-                dropdownFilm.style.display = 'none';
-            }
-        });
+  function hide(dropdown) {
+    dropdown.style.display = 'none';
+  }
+
+  if (filmLink && filmDropdown) {
+    filmLink.addEventListener('mouseenter', () => {
+      show(filmDropdown);
+      hide(digitalDropdown);
     });
 
-    document.addEventListener('click', (e) => {
-        if (!e.target.closest('.dropdown') && !e.target.classList.contains('dropdown-toggle')) {
-            dropdownFilm.style.display = 'none';
-            dropdownDigital.style.display = 'none';
-        }
+    filmLink.addEventListener('mouseleave', (e) => {
+      if (!filmDropdown.contains(e.relatedTarget)) {
+        hide(filmDropdown);
+      }
     });
+
+    filmDropdown.addEventListener('mouseleave', (e) => {
+      if (!filmLink.contains(e.relatedTarget)) {
+        hide(filmDropdown);
+      }
+    });
+  }
+
+  if (digitalLink && digitalDropdown) {
+    digitalLink.addEventListener('mouseenter', () => {
+      show(digitalDropdown);
+      hide(filmDropdown);
+    });
+
+    digitalLink.addEventListener('mouseleave', (e) => {
+      if (!digitalDropdown.contains(e.relatedTarget)) {
+        hide(digitalDropdown);
+      }
+    });
+
+    digitalDropdown.addEventListener('mouseleave', (e) => {
+      if (!digitalLink.contains(e.relatedTarget)) {
+        hide(digitalDropdown);
+      }
+    });
+  }
 });

--- a/src/_includes/nav.njk
+++ b/src/_includes/nav.njk
@@ -20,8 +20,8 @@
 
 <div class="nav">
   <a href="/" {% if page.url == '/' %}aria-current="page"{% endif %}>LILAN</a>
-  <a href="/ecfc/" class="dropdown-toggle" {% if page.url in filmPages %}aria-current="page"{% endif %}>FILM</a>
-  <a href="/cinepath/" class="dropdown-toggle" {% if page.url in digitalPages or page.url.startsWith('/cinepath') %}aria-current="page"{% endif %}>DIGITAL</a>
+  <a href="/untitled-film/" class="dropdown-toggle film" {% if page.url in filmPages %}aria-current="page"{% endif %}>FILM</a>
+  <a href="/cinepath/" class="dropdown-toggle digital" {% if page.url in digitalPages or page.url.startsWith('/cinepath') %}aria-current="page"{% endif %}>DIGITAL</a>
   <a href="/cv/" {% if page.url == '/cv/' %}aria-current="page"{% endif %}>CV</a>
 
   <div class="dropdown_film">


### PR DESCRIPTION
## Summary
- show project lists when hovering Film or Digital in navigation
- clicking Film or Digital goes to the first project of each category
- guard dropdown script against missing navigation elements
- ensure index navigation text size matches other pages

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689505089eec832ea90f52e4492ed2d0