### PR TITLE
Fix dropdown hover gap beneath navigation

### DIFF
--- a/css/nav.css
+++ b/css/nav.css
@@ -129,6 +129,16 @@ body {
   padding-bottom: 30px;
 }
 
+.dropdown_film::before,
+.dropdown_digital::before {
+  content: "";
+  position: absolute;
+  top: -15px;
+  left: 0;
+  width: 100%;
+  height: 15px;
+}
+
 .dropdown_film a,
 .dropdown_digital a {
   line-height: 45px;


### PR DESCRIPTION
## Summary
- Extend FILM and DIGITAL dropdowns with invisible pseudo-elements to cover the hover gap while preserving original spacing

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build` *(fails: eleventy: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895e50f9ec4832e99a3358374bf4439