### PR TITLE
Ensure deploy workflow covers develop and Netlify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: Deploy Eleventy to GitHub Pages
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -35,6 +36,20 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: _site
+
+      - name: Trigger Netlify build hook
+        if: env.NETLIFY_BUILD_HOOK != ''
+        env:
+          NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
+        run: |
+          echo "Triggering Netlify build via hook"
+          curl -X POST -s -o /dev/null -w "%{http_code}\n" "$NETLIFY_BUILD_HOOK"
+
+      - name: Skip Netlify build (no hook configured)
+        if: env.NETLIFY_BUILD_HOOK == ''
+        env:
+          NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
+        run: echo "NETLIFY_BUILD_HOOK secret not set; skipping Netlify trigger"
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ This site is built with [Eleventy](https://www.11ty.dev/).
    The generated site will be in the `_site` directory.
 
 All HTML files live in the `src/` directory and share a common layout with global navigation and scripts. Static assets such as CSS and JavaScript are copied to the output unchanged.
+
+## Deployment
+
+- **GitHub Pages (lilanyang.studio):** Pushing to `develop` or `master` runs the `Deploy Eleventy to GitHub Pages` workflow, which builds the site and publishes `_site` to Pages.
+- **Netlify (lilanyang.netlify.app):** Add a repository secret named `NETLIFY_BUILD_HOOK` with your site’s build hook URL. The workflow will trigger it on each push to `develop` or `master` after the build completes. If the secret is unset, the workflow will skip the Netlify trigger while still completing the GitHub Pages deploy.


### PR DESCRIPTION
## Summary
- trigger the deployment workflow on both develop and master pushes and allow manual runs
- add optional Netlify build-hook trigger alongside the GitHub Pages artifact upload
- document how the GitHub Pages and Netlify deployments are initiated

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f32512064832ebfa732645abac916)