### PR TITLE
Ensure map stays full screen on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -237,7 +237,11 @@ body {
   }
 
   #map {
-    position: relative;
-    z-index: 1;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
   }
 }


### PR DESCRIPTION
## Summary
- keep the index page map fixed and full-screen on viewports under 1200px
- ensure the about section remains readable while the map stays in the background

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f980cb124832e9fc412616068cf86)