### PR TITLE
Add extensionless page support

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,3 +1,6 @@
+const fs = require("fs");
+const path = require("path");
+
 module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("css");
   eleventyConfig.addPassthroughCopy("js");
@@ -7,6 +10,43 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("kml");
   eleventyConfig.addPassthroughCopy("icon");
   eleventyConfig.addPassthroughCopy("favicon.ico");
+
+  eleventyConfig.on("afterBuild", async () => {
+    const outputDir = "_site";
+    const entries = await fs.promises.readdir(outputDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith(".html")) {
+        if (entry.name === "index.html" || entry.name === "404.html") {
+          continue;
+        }
+
+        const slug = entry.name.slice(0, -5);
+        const destination = path.join(outputDir, slug, "index.html");
+
+        await fs.promises.mkdir(path.dirname(destination), { recursive: true });
+        await fs.promises.copyFile(path.join(outputDir, entry.name), destination);
+      }
+
+      if (entry.isDirectory()) {
+        const indexPath = path.join(outputDir, entry.name, "index.html");
+        const htmlPath = path.join(outputDir, `${entry.name}.html`);
+
+        try {
+          await fs.promises.access(indexPath, fs.constants.F_OK);
+        } catch {
+          continue;
+        }
+
+        try {
+          await fs.promises.access(htmlPath, fs.constants.F_OK);
+        } catch {
+          await fs.promises.copyFile(indexPath, htmlPath);
+        }
+      }
+    }
+  });
+
   return {
     dir: { input: "src", output: "_site" }
   };


### PR DESCRIPTION
## Summary
- add an Eleventy afterBuild hook to copy HTML pages into matching folders with index files
- create reverse copies so clean URLs and .html variants both resolve without manual redirects

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693222413b4c832eb1427f9b879137b6)