### PR TITLE
Improve mobile typography scaling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -228,8 +228,56 @@ body {
 }
 
 @media (max-width: 1200px) {
-		.about {
-			width: 90%;
-			padding-left: 5%;
-		}
+                .about {
+                        width: 90%;
+                        padding-left: 5%;
+                }
+}
+
+@media (max-width: 600px) {
+  ul,
+  li,
+  a,
+  p,
+  span {
+    font-size: 18px;
+    line-height: 27px;
+  }
+
+  .basic_info p {
+    font-size: 27px;
+    margin-top: 24px;
+  }
+
+  .description p,
+  .bio p,
+  .about p {
+    font-size: 18px;
+    line-height: 27px;
+    margin-top: 12px;
+  }
+
+  .skillset p {
+    margin-top: 18px;
+  }
+
+  .skillset span,
+  .content span,
+  .bio span,
+  .about span {
+    line-height: 32px;
+    font-size: 18px;
+    border-width: 4px;
+    padding: 4px 14px;
+    border-radius: 60px;
+    margin-top: 10px;
+    margin-right: 4px;
+  }
+
+  .about {
+    padding-top: 45px;
+    margin-top: 45px;
+    line-height: 32px;
+    font-size: 18px;
+  }
 }


### PR DESCRIPTION
## Summary
- add a mobile-specific media query to scale body text to 18px and tighten margins on screens under 600px
- reduce span border widths and padding for badges and links to match the smaller font size
- adjust about section spacing for improved readability on narrow viewports

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69341294d228832e949f6ead19c19b87)