### PR TITLE
Implement mobile hamburger navigation overlay

### DIFF
--- a/css/nav.css
+++ b/css/nav.css
@@ -30,6 +30,18 @@ body {
   background-attachment: fixed;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* navigations */
 .nav {
   background-color: rgba(0, 0, 0, 0.9);
@@ -38,10 +50,53 @@ body {
   /* 75% */
   width: 100%;
   position: fixed;
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   z-index: 3;
   text-align: center;
 }
+
+.nav-menu {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  height: 100%;
+}
+
+.nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 50px;
+  margin-left: 16px;
+  border: none;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  position: relative;
+}
+
+.nav-toggle__icon,
+.nav-toggle__icon::before,
+.nav-toggle__icon::after {
+  content: "";
+  position: absolute;
+  width: 28px;
+  height: 3px;
+  background: #fff;
+  transition: transform 0.25s ease, opacity 0.25s ease, background 0.25s ease;
+}
+
+.nav-toggle__icon { top: 50%; transform: translateY(-50%); }
+.nav-toggle__icon::before { transform: translateY(-8px); }
+.nav-toggle__icon::after { transform: translateY(8px); }
+
+.nav-toggle.is-open .nav-toggle__icon { background: transparent; }
+.nav-toggle.is-open .nav-toggle__icon::before { transform: translateY(0) rotate(45deg); }
+.nav-toggle.is-open .nav-toggle__icon::after { transform: translateY(0) rotate(-45deg); }
 
 .nav a {
   line-height: 60px;
@@ -203,5 +258,54 @@ body {
 
   .left_nav.cv-nav {
     display: flex;
+  }
+}
+
+@media (max-width: 900px) {
+  .nav {
+    justify-content: flex-start;
+    padding: 0 12px;
+  }
+
+  .nav-menu {
+    display: none;
+  }
+
+  .nav-toggle {
+    display: flex;
+  }
+
+  .nav-menu.is-open {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 28px;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.95);
+    z-index: 4;
+    text-align: center;
+  }
+
+  .nav-menu.is-open a {
+    border: none;
+    font-size: 40px;
+    margin: 0;
+  }
+
+  .nav-menu.is-open .dropdown_film {
+    position: static;
+    display: none;
+    background: transparent;
+    width: 100%;
+    padding: 0 5%;
+    margin-top: 0;
+  }
+
+  .nav-menu.is-open .dropdown_film a {
+    display: block;
+    line-height: 40px;
+    font-size: 32px;
   }
 }

--- a/docs/mobile-nav-outline.md
+++ b/docs/mobile-nav-outline.md
@@ -1,0 +1,24 @@
+# Mobile nav outline
+
+1. **Add a hamburger trigger to the nav template**
+   - Insert a button (e.g., `<button class="nav-toggle" aria-expanded="false">≡</button>`) inside `.nav`, before the existing links. Keep the text centered and no underline; hide it on desktop and show it only under 900 px using CSS.
+
+2. **Wrap the existing links in a container that can be toggled**
+   - Group `LILAN`, `FILM`, and `CV` plus `.dropdown_film` inside a wrapper (e.g., `.nav-menu`). This allows you to hide the menu on mobile until the hamburger is tapped.
+
+3. **Mobile-first styling in `css/nav.css`**
+   - Add base styles for `.nav-toggle`: 50×50 px box, no border/underline, center the ≡ text, left-align the nav bar, and keep it `display:none` by default.
+   - In `@media (max-width: 900px)`, switch `.nav` to `display:flex` with `justify-content: space-between; align-items:center; padding` to position the toggle on the left. Show `.nav-toggle` (`display:flex`), hide `.nav-menu` by default (`display:none;`), and remove the underlines on links when inside the mobile dropdown.
+   - Create a fullscreen dropdown style for the open state (e.g., `.nav-menu.is-open { position: fixed; inset: 0; background: rgba(0,0,0,0.95); display:flex; flex-direction:column; align-items:center; justify-content:center; gap: 32px; }`). Reuse the existing `.dropdown_film` links inside it; you can set `.dropdown_film` to `display:block; width:100%; text-align:center;` when the menu is open.
+
+4. **JavaScript toggle behavior**
+   - Attach a small script (inline or separate) to toggle a class like `.is-open` on the menu and update `aria-expanded` on the button when the hamburger is clicked. Also toggle `.dropdown_film` visibility on `FILM` clicks so the film list fills the screen; you can reuse the same overlay container to stack the main links and the film sublinks.
+
+5. **Dropdown interaction**
+   - On mobile, treat `FILM` as a trigger: clicking it can either navigate or toggle the film list. To keep behavior consistent, prevent default on mobile and set `.dropdown_film` to `display:block` while overlay is open. Ensure links remain center-aligned by applying `text-align:center` to the overlay’s anchor styling.
+
+6. **Accessibility tips**
+   - Use `aria-expanded` on the hamburger, `aria-controls` pointing to the menu container, and allow Esc key or overlay click to close the menu. Keep focus trapped in the overlay when open for better keyboard support.
+
+7. **Animate the hamburger into an × when open**
+   - Apply a class like `.is-open` to the toggle button and use CSS transitions (e.g., pseudo-elements turning the three lines into a rotated cross) or swap the character so the ≡ morphs into an “×” as the menu opens, then back to ≡ when closed.

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -3,10 +3,15 @@
 document.addEventListener('DOMContentLoaded', () => {
   const filmLink = document.querySelector('.dropdown-toggle.film');
   const filmDropdown = document.querySelector('.dropdown_film');
+  const navMenu = document.querySelector('#nav-menu');
+  const navToggle = document.querySelector('.nav-toggle');
+  const nav = document.querySelector('.nav');
 
   const dropdowns = [
     { link: filmLink, menu: filmDropdown }
   ];
+
+  const isMobileView = () => window.matchMedia('(max-width: 900px)').matches;
 
   function hideAll() {
     dropdowns.forEach(({ link, menu }) => {
@@ -17,6 +22,35 @@ document.addEventListener('DOMContentLoaded', () => {
         link.setAttribute('aria-expanded', 'false');
       }
     });
+  }
+
+  function closeMenu() {
+    if (navMenu) {
+      navMenu.classList.remove('is-open');
+    }
+    if (navToggle) {
+      navToggle.classList.remove('is-open');
+      navToggle.setAttribute('aria-expanded', 'false');
+    }
+    hideAll();
+  }
+
+  function openMenu() {
+    if (navMenu) {
+      navMenu.classList.add('is-open');
+    }
+    if (navToggle) {
+      navToggle.classList.add('is-open');
+      navToggle.setAttribute('aria-expanded', 'true');
+    }
+  }
+
+  function toggleMenu() {
+    if (navMenu && navMenu.classList.contains('is-open')) {
+      closeMenu();
+      return;
+    }
+    openMenu();
   }
 
   function toggleDropdown(targetDropdown, targetLink) {
@@ -30,6 +64,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   document.addEventListener('click', (event) => {
+    if (isMobileView()) {
+      return;
+    }
     const clickedFilm = filmLink && filmLink.contains(event.target);
 
     if (clickedFilm) {
@@ -52,6 +89,64 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!clickedInsideDropdown) {
       hideAll();
+    }
+  });
+
+  navToggle?.addEventListener('click', (event) => {
+    event.stopPropagation();
+    toggleMenu();
+  });
+
+  filmLink?.addEventListener('click', (event) => {
+    if (isMobileView()) {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!navMenu?.classList.contains('is-open')) {
+        openMenu();
+      }
+      const isOpen = filmDropdown && filmDropdown.style.display === 'block';
+      hideAll();
+      if (!isOpen) {
+        filmDropdown && (filmDropdown.style.display = 'block');
+        filmLink.setAttribute('aria-expanded', 'true');
+      }
+      return;
+    }
+  });
+
+  document.addEventListener('click', (event) => {
+    const clickedInsideDropdown = dropdowns.some(({ menu }) => menu && menu.contains(event.target));
+
+    if (isMobileView()) {
+      const clickedInsideNav = nav && nav.contains(event.target);
+      if (!clickedInsideNav) {
+        closeMenu();
+      }
+      if (!clickedInsideDropdown) {
+        hideAll();
+      }
+      return;
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closeMenu();
+    }
+  });
+
+  navMenu?.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    if (!isMobileView()) return;
+    if (target.tagName === 'A' && !target.classList.contains('dropdown-toggle')) {
+      closeMenu();
+    }
+  });
+
+  window.addEventListener('resize', () => {
+    if (!isMobileView()) {
+      closeMenu();
     }
   });
 

--- a/src/_includes/nav.njk
+++ b/src/_includes/nav.njk
@@ -10,18 +10,25 @@
 ] %}
 
 <div class="nav">
-  <a href="/" {% if page.url == '/' %}aria-current="page"{% endif %}>LILAN</a>
-  <a href="/untitled-film/" class="dropdown-toggle film" {% if page.url in filmPages or page.url.startsWith('/cinepath') %}aria-current="page"{% endif %}>FILM</a>
-  <a href="/cv/" {% if page.url == '/cv/' %}aria-current="page"{% endif %}>CV</a>
+  <button class="nav-toggle" aria-expanded="false" aria-controls="nav-menu">
+    <span class="sr-only">Toggle navigation</span>
+    <span class="nav-toggle__icon" aria-hidden="true"></span>
+  </button>
 
-  <div class="dropdown_film">
-    <a href="/untitled-film/">UNTITLED FILM DISINFECTION PROJECT</a><br><br>
-    <a href="/ecfc/">EVERYTHING COMES FULL CIRCLE</a><br><br>
-    <a href="/perfect-human/">THE PERFECT HUMAN</a><br><br>
-    <a href="/the-force/">THE FORCE THAT THROUGH THE GREEN FUSE DRIVES THE FLOWER</a><br><br>
-    <a href="/untitled-pvd-bos/">UNTITLED: FROM PVD TO BOS</a><br><br>
-    <a href="/woke-up/">I WOKE UP IN THE MORNING</a><br><br>
-    <a href="/cineml/">CINEML: PARIS</a><br><br>
-    <a href="/cinepath/">CINEPATH</a>
+  <div id="nav-menu" class="nav-menu">
+    <a href="/" {% if page.url == '/' %}aria-current="page"{% endif %}>LILAN</a>
+    <a href="/untitled-film/" class="dropdown-toggle film" {% if page.url in filmPages or page.url.startsWith('/cinepath') %}aria-current="page"{% endif %}>FILM</a>
+    <a href="/cv/" {% if page.url == '/cv/' %}aria-current="page"{% endif %}>CV</a>
+
+    <div class="dropdown_film">
+      <a href="/untitled-film/">UNTITLED FILM DISINFECTION PROJECT</a><br><br>
+      <a href="/ecfc/">EVERYTHING COMES FULL CIRCLE</a><br><br>
+      <a href="/perfect-human/">THE PERFECT HUMAN</a><br><br>
+      <a href="/the-force/">THE FORCE THAT THROUGH THE GREEN FUSE DRIVES THE FLOWER</a><br><br>
+      <a href="/untitled-pvd-bos/">UNTITLED: FROM PVD TO BOS</a><br><br>
+      <a href="/woke-up/">I WOKE UP IN THE MORNING</a><br><br>
+      <a href="/cineml/">CINEML: PARIS</a><br><br>
+      <a href="/cinepath/">CINEPATH</a>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add a hamburger toggle and wrapped nav menu markup for mobile
- style the mobile overlay dropdown and animate the hamburger into an × when opened
- update dropdown script to manage mobile toggling, overlay closing, and keyboard escape handling

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934334551f0832ebb20517680f464d9)