### PR TITLE
feat: optimize SEO and AEO metadata across the site

### DIFF
--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -9,10 +9,58 @@
     gtag('js', new Date());
     gtag('config', 'G-V4G00WYERF');
   </script>
+
+  {%- set siteUrl = "https://lilanyang.studio" -%}
+  {%- set siteName = "Lilan Yang" -%}
+  {%- set siteAuthor = "Lilan Yang" -%}
+  {%- set defaultDescription = "Lilan Yang is a moving image artist working with 16mm film, installation, photography, and performance. Based in Boston, exploring migration, memory, and perception." -%}
+  {%- set pageUrl = siteUrl + page.url -%}
+  {%- set rawDescription = description | default(defaultDescription) -%}
+  {%- set cleanDescription = rawDescription | striptags | replace('  ', ' ') | trim -%}
+  {%- set pageImage = og_image | default("/img/index/ecfc.png") -%}
+  {%- if "http" in pageImage -%}
+    {%- set pageImageAbs = pageImage -%}
+  {%- else -%}
+    {%- set pageImageAbs = siteUrl + pageImage -%}
+  {%- endif -%}
+  {%- set pageSchemaType = schema_type | default('WebPage') -%}
+  {%- set ogType = og_type | default('website') -%}
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="{{ description }}">
+  <meta name="description" content="{{ cleanDescription }}">
+  {%- if keywords %}
+  <meta name="keywords" content="{{ keywords }}">
+  {%- endif %}
+  <meta name="author" content="{{ siteAuthor }}">
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+  <meta name="googlebot" content="index, follow">
+  <meta name="theme-color" content="#000000">
+
+  <link rel="canonical" href="{{ pageUrl }}">
   <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="apple-touch-icon" href="/favicon.ico" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="{{ ogType }}">
+  <meta property="og:site_name" content="{{ siteName }}">
+  <meta property="og:title" content="{{ title }}">
+  <meta property="og:description" content="{{ cleanDescription }}">
+  <meta property="og:url" content="{{ pageUrl }}">
+  <meta property="og:image" content="{{ pageImageAbs }}">
+  <meta property="og:image:alt" content="{{ title }}">
+  <meta property="og:locale" content="en_US">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ title }}">
+  <meta name="twitter:description" content="{{ cleanDescription }}">
+  <meta name="twitter:image" content="{{ pageImageAbs }}">
+  <meta name="twitter:image:alt" content="{{ title }}">
+
+  <link rel="preconnect" href="https://www.googletagmanager.com">
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
   <link rel="stylesheet" href="/css/nav.css" type="text/css">
   {% if styles %}
   {% for style in styles %}
@@ -25,6 +73,105 @@
   <script src="/{{ script }}"></script>
   {% endfor %}
   {% endif %}
+
+  {%- if page.url == '/' %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Lilan Yang",
+    "alternateName": "Lilan Yang Studio",
+    "url": "{{ siteUrl }}",
+    "image": "{{ siteUrl }}/img/index/ecfc.png",
+    "jobTitle": "Artist and Filmmaker",
+    "description": "Moving image artist working with 16mm film, installation, photography, and performance. Rooted in the materiality of 16mm, the practice explores the flux of migration, the decay of memory, and the intricacies of perception.",
+    "birthPlace": { "@type": "Place", "name": "Chongqing, China" },
+    "workLocation": {
+      "@type": "Place",
+      "name": "Boston, Massachusetts, USA",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Boston",
+        "addressRegion": "MA",
+        "addressCountry": "US"
+      }
+    },
+    "nationality": { "@type": "Country", "name": "China" },
+    "knowsAbout": [
+      "16mm film",
+      "Experimental film",
+      "Moving image art",
+      "Film installation",
+      "Analog filmmaking",
+      "Computational photography",
+      "Machine learning in art",
+      "Memory and perception",
+      "Migration"
+    ],
+    "alumniOf": [
+      { "@type": "CollegeOrUniversity", "name": "Rhode Island School of Design", "sameAs": "https://www.risd.edu/" },
+      { "@type": "CollegeOrUniversity", "name": "University of Illinois at Urbana-Champaign", "sameAs": "https://illinois.edu/" }
+    ],
+    "sameAs": [
+      "https://www.instagram.com/lilanyang.studio/"
+    ],
+    "email": "mailto:lilanyang.studio@gmail.com"
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "{{ siteName }}",
+    "alternateName": "Lilan Yang Studio",
+    "url": "{{ siteUrl }}",
+    "inLanguage": "en",
+    "author": {
+      "@type": "Person",
+      "name": "Lilan Yang",
+      "url": "{{ siteUrl }}"
+    }
+  }
+  </script>
+  {%- endif %}
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "{{ pageSchemaType }}",
+    "name": {{ title | dump | safe }},
+    "headline": {{ title | dump | safe }},
+    "description": {{ cleanDescription | dump | safe }},
+    "url": "{{ pageUrl }}",
+    "image": "{{ pageImageAbs }}",
+    "inLanguage": "en",
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "{{ siteName }}",
+      "url": "{{ siteUrl }}"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Lilan Yang",
+      "url": "{{ siteUrl }}"
+    },
+    "creator": {
+      "@type": "Person",
+      "name": "Lilan Yang",
+      "url": "{{ siteUrl }}"
+    },
+    "publisher": {
+      "@type": "Person",
+      "name": "Lilan Yang",
+      "url": "{{ siteUrl }}"
+    }{% if date_published %},
+    "datePublished": "{{ date_published }}"{% endif %}{% if genre %},
+    "genre": {{ genre | dump | safe }}{% endif %}{% if artMedium %},
+    "artMedium": {{ artMedium | dump | safe }}{% endif %}{% if artform %},
+    "artform": {{ artform | dump | safe }}{% endif %}
+  }
+  </script>
 </head>
 <body{% if body_id %} id="{{ body_id }}"{% endif %}>
   <div class="container">

--- a/src/aaff.html
+++ b/src/aaff.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Ann Arbor Film Festival"
-description: "Lilan Yang's participation in the 61st Ann Arbor Film Festival, featuring film installation <i>Everything Comes Full Circle</i>."
+title: "Ann Arbor Film Festival — Lilan Yang"
+description: "Lilan Yang's participation in the 61st Ann Arbor Film Festival 'Off the Screen' exhibition, featuring the film installation Everything Comes Full Circle."
+keywords: "Ann Arbor Film Festival, Off the Screen, Lilan Yang, Everything Comes Full Circle, 16mm film installation"
+schema_type: "ExhibitionEvent"
+og_image: "/img/exhibitions/aaff/AAFF-Install.jpg"
 body_id: aaff
 styles:
 - css/projects.css

--- a/src/aide-memoire.html
+++ b/src/aide-memoire.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Aide-Mémoire"
-description: "<i>Aide-Mémoire</i>: The Films of Lilan Yang, Lilan Yang's debut solo screening in Canada featuring a curated selection of experimental films exploring memory and perception."
+title: "Aide-Mémoire — Solo Screening at Hamilton Artists Inc. — Lilan Yang"
+description: "Aide-Mémoire: The Films of Lilan Yang, Lilan Yang's debut solo screening in Canada at Hamilton Artists Inc., featuring experimental films exploring memory and perception."
+keywords: "Aide-Memoire, Lilan Yang, Hamilton Artists Inc, solo screening, experimental film, memory, perception, Canada"
+schema_type: "ExhibitionEvent"
+og_image: "/img/exhibitions/aide-memoire/am-poster-1.jpg"
 body_id: aide-memoire
 styles:
 - css/projects.css

--- a/src/alchemy.html
+++ b/src/alchemy.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Alchemy Film and Moving Image Festival"
-description: "Lilan Yang's installation <i>Everything Comes Full Circle</i> at the Alchemy Film and Moving Image Festival."
+title: "Alchemy Film and Moving Image Festival — Lilan Yang"
+description: "Lilan Yang's 16mm film installation Everything Comes Full Circle exhibited at the Alchemy Film and Moving Image Festival in Hawick, Scotland."
+keywords: "Alchemy Film and Moving Image Festival, Hawick, Scotland, Lilan Yang, Everything Comes Full Circle"
+schema_type: "ExhibitionEvent"
+og_image: "/img/exhibitions/alchemy/Alchemy-ECFC.jpg"
 body_id: alchemy
 styles:
 - css/projects.css

--- a/src/atlas.html
+++ b/src/atlas.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Atlas at Foxy Production"
-description: "Atlas, a group exhibition at Foxy Production featuring Lilan Yang's <i>CineML: Paris</i>, exploring cartographies of potentiality and personal geographies."
+title: "Atlas at Foxy Production — Lilan Yang"
+description: "Atlas, a group exhibition at Foxy Production in New York featuring Lilan Yang's CineML: Paris, exploring cartographies of potentiality and personal geographies."
+keywords: "Atlas, Foxy Production, New York, group exhibition, Lilan Yang, CineML Paris"
+schema_type: "ExhibitionEvent"
+og_image: "/img/exhibitions/atlas/FP_0.jpg"
 body_id: atlas
 styles:
 - css/projects.css

--- a/src/cineml.html
+++ b/src/cineml.html
@@ -1,7 +1,12 @@
 ---
 layout: layout.njk
-title: "CineML: Paris 🌇"
-description: "CineML: Paris, a machine learning project by Lilan Yang generating non-existent images of Paris using a StyleGAN model trained on social media posts."
+title: "CineML: Paris — Lilan Yang"
+description: "CineML: Paris, a machine learning project by Lilan Yang generating a city symphony of non-existent Paris images using a StyleGAN model trained on social media posts."
+keywords: "CineML Paris, Lilan Yang, StyleGAN, machine learning art, city symphony, generative Paris, AI-generated film"
+schema_type: "CreativeWork"
+genre: "Generative art, City symphony"
+artMedium: "StyleGAN, Machine learning"
+og_image: "/img/projects/cineml/Yang-CineML-Still-1.jpeg"
 body_id: cineml
 styles:
   - css/projects.css

--- a/src/cinepath-before-sunrise.html
+++ b/src/cinepath-before-sunrise.html
@@ -1,6 +1,9 @@
 ---
 layout: layout.njk
-title: "Before Sunrise - Cinepath"
+title: "Before Sunrise — Cinepath"
+description: "Cinepath case study by Lilan Yang: visualizing the narrative path and character movements in Richard Linklater's Before Sunrise on Google Maps."
+keywords: "Cinepath, Before Sunrise, Richard Linklater, film location map, Lilan Yang, data visualization"
+schema_type: "CreativeWork"
 styles:
   - css/cinepath.css
 ---

--- a/src/cinepath-before-sunset.html
+++ b/src/cinepath-before-sunset.html
@@ -1,6 +1,9 @@
 ---
 layout: layout.njk
-title: "Before Sunrise - Cinepath"
+title: "Before Sunset — Cinepath"
+description: "Cinepath case study by Lilan Yang: visualizing the narrative path and character movements in Richard Linklater's Before Sunset on Google Maps."
+keywords: "Cinepath, Before Sunset, Richard Linklater, film location map, Lilan Yang, data visualization"
+schema_type: "CreativeWork"
 styles:
   - css/cinepath.css
 ---

--- a/src/cinepath-dataviz.html
+++ b/src/cinepath-dataviz.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Cinepath | Lilan Yang"
-description: "Cinepath, an interactive map and analysis of narrative structures in cinema by Lilan Yang."
+title: "Cinepath — Interactive Map — Lilan Yang"
+description: "Cinepath, an interactive map and analysis of narrative structures and character movements in cinema by Lilan Yang."
+keywords: "Cinepath, Lilan Yang, interactive map, narrative visualization, cinema data visualization"
+schema_type: "CreativeWork"
+og_image: "/img/projects/cinepath/paris_texas.jpg"
 body_id: cinepath
 styles:
   - css/projects.css

--- a/src/cinepath-frances-ha.html
+++ b/src/cinepath-frances-ha.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Frances Ha 🗽 Cinepath"
-description: "Cinepath case study: visualizing the narrative path and character movements in Noah Baumbach's Frances Ha."
+title: "Frances Ha — Cinepath — Lilan Yang"
+description: "Cinepath case study by Lilan Yang: visualizing the narrative path and character movements in Noah Baumbach's Frances Ha on Google Maps."
+keywords: "Frances Ha, Noah Baumbach, Cinepath, Lilan Yang, film location map, data visualization"
+schema_type: "CreativeWork"
+og_image: "/img/projects/cinepath/frances_ha.jpg"
 styles:
   - css/style-frances-ha.css
 ---

--- a/src/cinepath-paris-texas-v2.html
+++ b/src/cinepath-paris-texas-v2.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Paris, Texas v2 🏜️ Cinepath"
-description: "Cinepath case study: visualizing the narrative path and character movements in Wim Wenders' Paris, Texas."
+title: "Paris, Texas (v2) — Cinepath — Lilan Yang"
+description: "Cinepath case study by Lilan Yang: second revision of the narrative path and character movement visualization in Wim Wenders' Paris, Texas."
+keywords: "Paris Texas, Wim Wenders, Cinepath, Lilan Yang, film location map, data visualization"
+schema_type: "CreativeWork"
+og_image: "/img/projects/cinepath/v2-paris-texas.png"
 styles:
   - css/style-paris-texas.css
 ---

--- a/src/cinepath-paris-texas.html
+++ b/src/cinepath-paris-texas.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Paris, Texas v1 🏜️ Cinepath"
-description: "Cinepath case study: visualizing the narrative path and character movements in Wim Wenders' Paris, Texas."
+title: "Paris, Texas (v1) — Cinepath — Lilan Yang"
+description: "Cinepath case study by Lilan Yang: visualizing the narrative path and character movements in Wim Wenders' Paris, Texas on Google Maps."
+keywords: "Paris Texas, Wim Wenders, Cinepath, Lilan Yang, film location map, data visualization"
+schema_type: "CreativeWork"
+og_image: "/img/projects/cinepath/paris_texas.jpg"
 styles:
   - css/style-paris-texas.css
 ---

--- a/src/cinepath.html
+++ b/src/cinepath.html
@@ -1,7 +1,12 @@
 ---
 layout: layout.njk
-title: "Cinepath 📍"
-description: "CinePath, a data visualization project by Lilan Yang mapping narrative structures and character movements in cinema."
+title: "Cinepath — Lilan Yang"
+description: "Cinepath, a data visualization project by Lilan Yang mapping narrative structures and character movements in cinema on Google Maps, including Paris, Texas, Frances Ha, and the Before trilogy."
+keywords: "Cinepath, Lilan Yang, film location map, data visualization, Paris Texas, Frances Ha, Before Sunrise, Before Sunset, cinema cartography"
+schema_type: "CreativeWork"
+genre: "Data visualization, Interactive art"
+artMedium: "Google Maps, Web"
+og_image: "/img/projects/cinepath/paris_texas.jpg"
 body_id: cinepath
 styles:
   - css/projects.css

--- a/src/cv.html
+++ b/src/cv.html
@@ -1,7 +1,9 @@
 ---
 layout: layout.njk
-title: "Lilan Yang - Curriculum Vitae 📽️"
-description: "Curriculum Vitae of Lilan Yang, detailing education, exhibitions, residencies, awards, and film festival screenings."
+title: "Lilan Yang — Curriculum Vitae"
+description: "Curriculum Vitae of Lilan Yang — education, solo exhibitions, residencies, awards, group exhibitions, film festivals, and press for the Boston-based moving image artist."
+keywords: "Lilan Yang CV, Lilan Yang resume, Lilan Yang biography, Lilan Yang exhibitions, Lilan Yang residencies, Lilan Yang awards, RISD MFA, Boston artist"
+schema_type: "AboutPage"
 body_id: wokeup
 styles:
   - css/projects.css

--- a/src/dm.html
+++ b/src/dm.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Digital + Media Biennial"
-description: "Digital + Media Biennial exhibition page featuring works by Lilan Yang's <i>the Perfect Human</i>"
+title: "Digital + Media Biennial at RISD — Lilan Yang"
+description: "Digital + Media Biennial exhibition at the Rhode Island School of Design featuring Lilan Yang's The Perfect Human."
+keywords: "Digital + Media Biennial, RISD, Rhode Island School of Design, Lilan Yang, The Perfect Human"
+schema_type: "ExhibitionEvent"
+og_image: "/img/exhibitions/dm/D+M_ThePerfectHuman.jpg"
 body_id: dm
 styles:
 - css/projects.css

--- a/src/ecfc.html
+++ b/src/ecfc.html
@@ -1,7 +1,12 @@
 ---
 layout: layout.njk
-title: "Everything Comes Full Circle 🌌"
-description: "<i>Everything Comes Full Circle</i>, a 16mm film installation by Lilan Yang investigating the cyclic nature of memory."
+title: "Everything Comes Full Circle — Lilan Yang"
+description: "Everything Comes Full Circle, a 16mm film installation with inkjet-printed film by Lilan Yang investigating the cyclic nature of memory."
+keywords: "Everything Comes Full Circle, Lilan Yang, 16mm film installation, inkjet-printed film, memory, experimental film, RISD MFA thesis"
+schema_type: "CreativeWork"
+genre: "Experimental film"
+artMedium: "16mm film, inkjet-printed film"
+og_image: "/img/projects/ecfc/film-installation.jpg"
 body_id: ecfc
 styles:
   - css/projects.css

--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Lilan Yang - Index 🧳"
-description: "Portfolio of Lilan Yang, a moving image artist merging analog filmmaking with computational processes, exploring memory, migration, and perception."
+title: "Lilan Yang — Moving Image Artist"
+description: "Portfolio of Lilan Yang, a moving image artist based in Boston merging 16mm analog filmmaking with computational processes, exploring memory, migration, and perception."
+keywords: "Lilan Yang, moving image artist, 16mm film, experimental filmmaker, Boston artist, installation art, analog film, computational art, Chongqing, RISD MFA"
+schema_type: "ProfilePage"
+og_type: "profile"
 body_id: places
 styles:
   - css/style.css

--- a/src/llms.njk
+++ b/src/llms.njk
@@ -1,0 +1,69 @@
+---
+permalink: /llms.txt
+eleventyExcludeFromCollections: true
+---
+# Lilan Yang
+
+> Lilan Yang (b. Chongqing, China) is a moving image artist working with 16mm film, installation, photography, and performance. Rooted in the materiality of 16mm, their practice explores the flux of migration, the decay of memory, and the intricacies of perception. Lilan currently lives and works in Boston, Massachusetts.
+
+## About
+- Name: Lilan Yang
+- Birthplace: Chongqing, China
+- Based in: Boston, Massachusetts, USA
+- Education: MFA Digital + Media, Rhode Island School of Design (2022); BS Computer Engineering, University of Illinois at Urbana-Champaign (2019)
+- Website: https://lilanyang.studio
+- Instagram: https://www.instagram.com/lilanyang.studio/
+- Email: lilanyang.studio@gmail.com
+- Distributor: Canadian Filmmakers Distribution Centre (Toronto, Ontario, Canada)
+
+## Site
+- [Home](https://lilanyang.studio/): Portfolio index and biographical statement.
+- [CV](https://lilanyang.studio/cv/): Full curriculum vitae including education, solo exhibitions, residencies, awards, group exhibitions, festivals, and press.
+- [Performance](https://lilanyang.studio/ufdp-performance/): Live projector performance information.
+
+## Films and Moving Image Works
+- [Untitled Film Disinfection Project](https://lilanyang.studio/untitled-film/): 16mm structural film (2025) using chlorine dioxide to chemically alter Ektachrome, responding to China's zero-COVID policy and the White Paper Movement.
+- [Everything Comes Full Circle](https://lilanyang.studio/ecfc/): 16mm film installation with inkjet-printed film investigating the cyclic nature of memory (MFA thesis, 2022).
+- [The Perfect Human](https://lilanyang.studio/perfect-human/): Laser-printed-and-cut 16mm film remake of Jørgen Leth's 1967 film using StyleGAN2.
+- [The Force That Through the Green Fuse Drives the Flower](https://lilanyang.studio/the-force/): Site-specific installation titled after Dylan Thomas, on growth, decay, and the vitality of nature.
+- [Untitled: From PVD to BOS](https://lilanyang.studio/untitled-pvd-bos/): Slide show on the commuter rail journey between Providence and Boston.
+- [I Woke Up in the Morning](https://lilanyang.studio/woke-up/): 16mm film shot in Boston and Texas exploring the surreal space between dreams and waking life.
+- [CineML: Paris](https://lilanyang.studio/cineml/): Machine-learning city symphony generating non-existent Paris images with StyleGAN trained on social media posts.
+- [Cinepath](https://lilanyang.studio/cinepath/): Data-visualization project mapping narrative paths and character movements in cinema on Google Maps.
+
+## Cinepath Case Studies
+- [Paris, Texas (v1)](https://lilanyang.studio/cinepath-paris-texas/): Wim Wenders, 1984.
+- [Paris, Texas (v2)](https://lilanyang.studio/cinepath-paris-texas-v2/): Revised visualization.
+- [Frances Ha](https://lilanyang.studio/cinepath-frances-ha/): Noah Baumbach, 2012.
+- [Before Sunrise](https://lilanyang.studio/cinepath-before-sunrise/): Richard Linklater, 1995.
+- [Before Sunset](https://lilanyang.studio/cinepath-before-sunset/): Richard Linklater, 2004.
+
+## Selected Solo Exhibitions and Screenings
+- [Aide-Mémoire](https://lilanyang.studio/aide-memoire/): The Films of Lilan Yang, Hamilton Artists Inc., Hamilton, Ontario, Canada (2024).
+- [Nowhere Near](https://lilanyang.studio/nowhere-near/): Gallery 263, Cambridge, Massachusetts, USA (2023).
+
+## Selected Group Exhibitions and Festivals
+- [Synthetic Realities](https://lilanyang.studio/synthetic-realities/): Galerie Met, Berlin, Germany (2025).
+- [Atlas](https://lilanyang.studio/atlas/): Foxy Production, New York, USA (2023).
+- [Ann Arbor Film Festival — Off the Screen](https://lilanyang.studio/aaff/): Ann Arbor Art Center, Michigan, USA (2023).
+- [Alchemy Film and Moving Image Festival](https://lilanyang.studio/alchemy/): Hawick, Scotland, UK (2024).
+- [MONO NO AWARE XVI](https://lilanyang.studio/mono-no-aware/): Brooklyn, New York, USA (2022).
+- [RISD Grad Show 2022](https://lilanyang.studio/risd-grad-show/): Providence, Rhode Island, USA (2022).
+- [Digital + Media Biennial](https://lilanyang.studio/dm/): Rhode Island School of Design, Providence, USA.
+- [Of Soiled Bodies](https://lilanyang.studio/of-soiled-bodies/): Gelman Gallery, RISD Museum, Providence, USA (2022).
+
+## Selected Residencies
+- Embers of QIONG, Rotohaus, Sichuan, China (2026, forthcoming)
+- Boston Center for the Arts Studio Residency, Boston, Massachusetts, USA (2025–2028)
+- MASS MoCA General Residency, North Adams, Massachusetts, USA (2025)
+- BAL Residency, Baltic Analog Lab, Riga, Latvia (2025)
+- Millay Arts Core Residency, Austerlitz, New York, USA (2024)
+- Gallery 263 Artist-in-Residence, Cambridge, Massachusetts, USA (2023)
+- I-Park Residency, East Haddam, Connecticut, USA (2023)
+
+## Selected Awards
+- City of Boston Opportunity Fund, Mayor's Office of Arts and Culture (2025)
+- Puffin Foundation Grant (2025)
+- Best Experimental Short Film, Boston Short Film Festival (2024)
+- Award for Excellence, East Asian Experimental Competition, Image Forum Film Festival, Tokyo (2023)
+- Foundation for Contemporary Arts Emergency Grant (2023)

--- a/src/mono-no-aware.html
+++ b/src/mono-no-aware.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "MONO NO AWARE"
-description: "Documentation of Lilan Yang's installation at the MONO NO AWARE XVI Festival, showcasing 16mm film loops and projection setups."
+title: "MONO NO AWARE XVI — Lilan Yang"
+description: "Lilan Yang's installation at the MONO NO AWARE XVI Festival in Brooklyn, showcasing 16mm film loops and projection setups."
+keywords: "MONO NO AWARE, MONO NO AWARE XVI, Brooklyn, Lilan Yang, 16mm film loop, expanded cinema"
+schema_type: "ExhibitionEvent"
+og_image: "/img/exhibitions/mono/mono-1.jpeg"
 body_id: mono-no-aware
 styles:
 - css/projects.css

--- a/src/nowhere-near.html
+++ b/src/nowhere-near.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Nowhere Near at Gallery 263"
-description: "Nowhere Near, a solo exhibition by Lilan Yang at Gallery 263 presenting a body of work on displacement and distance."
+title: "Nowhere Near — Solo Exhibition at Gallery 263 — Lilan Yang"
+description: "Nowhere Near, a solo exhibition by Lilan Yang at Gallery 263 in Cambridge, Massachusetts presenting a body of work on displacement and distance."
+keywords: "Nowhere Near, Gallery 263, Cambridge Massachusetts, Lilan Yang, solo exhibition, displacement"
+schema_type: "ExhibitionEvent"
+og_image: "/img/exhibitions/nowhere-near/Nowhere-Near-Screening.jpg"
 body_id: nowhere-near
 styles:
 - css/projects.css

--- a/src/of-soiled-bodies.html
+++ b/src/of-soiled-bodies.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Of Soiled Bodies at RISD Museum"
-description: "Of Soiled Bodies, a group exhibition at the RISD Museum's Gelman Gallery featuring Lilan Yang, exploring themes of embodiment and abjection."
+title: "Of Soiled Bodies at RISD Museum — Lilan Yang"
+description: "Of Soiled Bodies, a group exhibition at the RISD Museum's Gelman Gallery in Providence featuring Lilan Yang, exploring themes of embodiment and abjection."
+keywords: "Of Soiled Bodies, RISD Museum, Gelman Gallery, Providence, Lilan Yang, group exhibition"
+schema_type: "ExhibitionEvent"
+og_image: "/img/exhibitions/of-soiled-bodies/OSB-1.jpg"
 body_id: wokeup
 styles:
 - css/projects.css

--- a/src/perfect-human.html
+++ b/src/perfect-human.html
@@ -1,7 +1,12 @@
 ---
 layout: layout.njk
-title: "The Perfect Human 🤵🏼‍♂️"
-description: "The Perfect Human, a generative video work by Lilan Yang using GANs to reimagine Jørgen Leth's 1967 film through the lens of AI."
+title: "The Perfect Human — Lilan Yang"
+description: "The Perfect Human, a laser-printed-and-cut 16mm film remake by Lilan Yang using StyleGAN2 to reimagine Jørgen Leth's 1967 film through the lens of machine learning."
+keywords: "The Perfect Human, Lilan Yang, StyleGAN2, GAN art, Jørgen Leth, generative film, 16mm film remake, machine learning art"
+schema_type: "CreativeWork"
+genre: "Experimental film, Generative art"
+artMedium: "16mm film, StyleGAN2"
+og_image: "/img/projects/perfect_human/Yang_the Perfect Human_BISFF.png"
 body_id: perfect-human
 styles:
   - css/projects.css

--- a/src/risd-grad-show.html
+++ b/src/risd-grad-show.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "RISD Grad Show"
-description: "RISD Grad Show 2022 exhibition page featuring Lilan Yang's MFA thesis work, <i>Everything Comes Full Circle</i>."
+title: "RISD Grad Show 2022 — Lilan Yang"
+description: "RISD Grad Show 2022 featuring Lilan Yang's Digital + Media MFA thesis work, Everything Comes Full Circle, in Providence, Rhode Island."
+keywords: "RISD Grad Show 2022, Rhode Island School of Design, Lilan Yang, MFA thesis, Everything Comes Full Circle, Digital + Media"
+schema_type: "ExhibitionEvent"
+og_image: "/img/exhibitions/risd-grad-show/ecfc-install.JPG"
 body_id: risd-grad-show
 styles:
 - css/projects.css

--- a/src/robots.njk
+++ b/src/robots.njk
@@ -1,0 +1,38 @@
+---
+permalink: /robots.txt
+eleventyExcludeFromCollections: true
+---
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+Sitemap: https://lilanyang.studio/sitemap.xml

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -1,0 +1,19 @@
+---
+permalink: /sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for item in collections.all %}
+  <url>
+    <loc>https://lilanyang.studio{{ item.url }}</loc>
+    {%- if item.url == '/' %}
+    <priority>1.0</priority>
+    <changefreq>monthly</changefreq>
+    {%- else %}
+    <priority>0.8</priority>
+    <changefreq>monthly</changefreq>
+    {%- endif %}
+  </url>
+{%- endfor %}
+</urlset>

--- a/src/synthetic-realities.html
+++ b/src/synthetic-realities.html
@@ -1,7 +1,10 @@
 ---
 layout: layout.njk
-title: "Synthetic Realities"
-description: "Synthetic Realities, a group exhibition featuring Lilan Yang's work examining authenticity and artificiality in the age of AI imagery."
+title: "Synthetic Realities at Galerie Met, Berlin — Lilan Yang"
+description: "Synthetic Realities: Authenticity in the Age of AI Imagery, a group exhibition at Galerie Met in Berlin featuring Lilan Yang's The Perfect Human."
+keywords: "Synthetic Realities, Galerie Met, Berlin, Germany, AI imagery, Lilan Yang, The Perfect Human, group exhibition"
+schema_type: "ExhibitionEvent"
+og_image: "/img/exhibitions/gm/GalerieMet-SR_Installation_View.jpg"
 body_id: synthetic-realities
 styles:
 - css/projects.css

--- a/src/the-force.html
+++ b/src/the-force.html
@@ -1,7 +1,11 @@
 ---
 layout: layout.njk
-title: "The force that through the green fuse drives the flower 🌱"
-description: "The force that through the green fuse drives the flower, a site-specific installation by Lilan Yang exploring growth, decay, and the vitality of nature."
+title: "The Force That Through the Green Fuse Drives the Flower — Lilan Yang"
+description: "A site-specific installation by Lilan Yang, titled after Dylan Thomas, exploring growth, decay, and the vitality of nature."
+keywords: "The Force That Through the Green Fuse Drives the Flower, Lilan Yang, site-specific installation, Dylan Thomas, nature, experimental art"
+schema_type: "CreativeWork"
+genre: "Installation art"
+og_image: "/img/projects/the_force/1_the Force.jpg"
 body_id: force
 styles:
   - css/projects.css

--- a/src/ufdp-performance.html
+++ b/src/ufdp-performance.html
@@ -1,7 +1,11 @@
 ---
 layout: layout.njk
-title: "Untitled Film Disinfection Project: Performance 🪧"
-description: "Performance page for <i>Untitled Film Disinfection Project</i> by Lilan Yang, featuring live projector performances and installations."
+title: "Performance — Untitled Film Disinfection Project — Lilan Yang"
+description: "Live projector performances by Lilan Yang for Untitled Film Disinfection Project, featuring hand-processed 16mm film altered with chlorine dioxide."
+keywords: "Lilan Yang performance, live projector performance, Untitled Film Disinfection Project, 16mm expanded cinema"
+schema_type: "CreativeWork"
+genre: "Performance art, Expanded cinema"
+og_image: "/img/projects/untitled-film/6f-still019.jpg"
 body_id: untitled-film
 styles:
 - css/projects.css

--- a/src/untitled-film.html
+++ b/src/untitled-film.html
@@ -1,7 +1,13 @@
 ---
 layout: layout.njk
-title: "Untitled Film Disinfection Project 🪧"
-description: "A 16mm structural film by Lilan Yang exploring state control and resistance through the chemical alteration of film."
+title: "Untitled Film Disinfection Project — Lilan Yang"
+description: "A 16mm structural film by Lilan Yang exploring state control and resistance through the chemical alteration of Ektachrome film, responding to China's zero-COVID policy and the White Paper Movement."
+keywords: "Untitled Film Disinfection Project, Lilan Yang, 16mm structural film, experimental film, China zero-COVID, White Paper Movement, chemical film alteration, Ektachrome"
+schema_type: "CreativeWork"
+genre: "Experimental film"
+artMedium: "16mm film"
+artform: "Structural film"
+og_image: "/img/projects/untitled-film/6f-still019.jpg"
 body_id: untitled-film
 styles:
   - css/projects.css

--- a/src/untitled-pvd-bos.html
+++ b/src/untitled-pvd-bos.html
@@ -1,7 +1,11 @@
 ---
 layout: layout.njk
-title: "Untitled: from Providence to Boston 🛣️"
+title: "Untitled: From Providence to Boston — Lilan Yang"
 description: "Untitled: from PVD to BOS, a slide show by Lilan Yang capturing the commuter rail journey between Providence and Boston."
+keywords: "Untitled from PVD to BOS, Lilan Yang, Providence, Boston, commuter rail, slide show, photography"
+schema_type: "CreativeWork"
+genre: "Photography, Slide show"
+og_image: "/img/projects/untitled/Untitled.jpg"
 body_id: untitled-pvd-bos
 styles:
   - css/projects.css

--- a/src/woke-up.html
+++ b/src/woke-up.html
@@ -1,7 +1,12 @@
 ---
 layout: layout.njk
-title: "I Woke Up in the Morning 🌫️"
-description: "<i>I Woke Up in the Morning</i>, a 16mm film by Lilan Yang exploring the surreal space between dreams and waking life."
+title: "I Woke Up in the Morning — Lilan Yang"
+description: "I Woke Up in the Morning, a 16mm film by Lilan Yang shot in Boston and Texas, exploring the surreal space between dreams and waking life."
+keywords: "I Woke Up in the Morning, Lilan Yang, 16mm film, Boston, Texas, experimental film, dream, memory"
+schema_type: "CreativeWork"
+genre: "Experimental film"
+artMedium: "16mm film"
+og_image: "/img/projects/wokeup/wokeup-texas.png"
 body_id: wokeup
 styles:
   - css/projects.css

--- a/src/work.html
+++ b/src/work.html
@@ -1,6 +1,8 @@
 ---
 layout: layout.njk
-title: "📂 Index"
+title: "Work Index — Lilan Yang"
+description: "Index of moving image works by Lilan Yang, including Everything Comes Full Circle, The Perfect Human, I Woke Up in the Morning, CineML: Paris, and Cinepath."
+keywords: "Lilan Yang, moving image, 16mm film, experimental film, installation art, film index"
 body_id: index
 styles:
   - css/style.css


### PR DESCRIPTION
Expand layout.njk with canonical URL, Open Graph, Twitter Card, robots,
theme-color, and Schema.org JSON-LD (Person + WebSite on the homepage,
WebPage/CreativeWork/ExhibitionEvent/ProfilePage/AboutPage per page).
Add per-page keywords, og_image, schema_type, genre, and artMedium
frontmatter for richer structured data without changing visible content.

Backfill missing titles and descriptions for work, cinepath-before-sunrise,
and cinepath-before-sunset. Strip inline HTML from descriptions before
emitting meta tags so values stay valid.

Add robots.txt (allowing major search and AI crawlers), sitemap.xml, and
llms.txt to improve discoverability for search engines and answer engines.