### PR TITLE
SEO/AEO + performance: metadata, title length, image compression, alt text, JSON-LD fix

### DIFF
--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -24,6 +24,8 @@
     {%- set pageImageAbs = siteUrl + pageImage -%}
   {%- endif -%}
   {%- set pageSchemaType = schema_type | default('WebPage') -%}
+  {%- set creativeWorkTypes = ['CreativeWork','VisualArtwork','Movie','VideoObject','Photograph','ImageObject','Article','BlogPosting','MediaObject','Painting','Sculpture'] -%}
+  {%- set isCreativeWork = pageSchemaType in creativeWorkTypes -%}
   {%- set ogType = og_type | default('website') -%}
 
   <meta charset="UTF-8">
@@ -150,7 +152,7 @@
       "@type": "WebSite",
       "name": "{{ siteName }}",
       "url": "{{ siteUrl }}"
-    },
+    }{% if isCreativeWork %},
     "author": {
       "@type": "Person",
       "name": "Lilan Yang",
@@ -165,7 +167,7 @@
       "@type": "Person",
       "name": "Lilan Yang",
       "url": "{{ siteUrl }}"
-    }{% if date_published %},
+    }{% endif %}{% if date_published %},
     "datePublished": "{{ date_published }}"{% endif %}{% if genre %},
     "genre": {{ genre | dump | safe }}{% endif %}{% if artMedium %},
     "artMedium": {{ artMedium | dump | safe }}{% endif %}{% if artform %},


### PR DESCRIPTION
## Summary

Three commits bundled:

- **`c29084c` SEO/AEO metadata** — canonical URLs, Open Graph + Twitter cards, JSON-LD (Person, WebSite, per-page), sitemap, robots.txt, and llms.txt across every page.
- **`56eb185` Performance pass** — shorten four overlong `<title>`s (68–70 → 47–52 chars), compress 196 images via Pillow (`/img/` 267 MB → 52 MB, `/frames/` 19 MB → 13 MB), convert 35 opaque PNGs to JPG where safe (HTML refs rewritten), add descriptive `alt` text on every `<img>`, add `loading="lazy"` + `decoding="async"` (first image per page uses `loading="eager" fetchpriority="high"` as LCP hint).
- **`1afafa6` JSON-LD fix** — clears the Google Search Console "Unrecognized field 'author'" warning by only emitting `author`/`creator`/`publisher` when `schema_type` is `CreativeWork` or a subtype. `WebPage`, `ProfilePage`, `AboutPage`, and `ExhibitionEvent` pages no longer emit those fields (Google doesn't recognize them there for rich results).

## Test plan

- [x] `npm run build` — 31 files written, no template errors
- [x] All `<img>` tags have both `alt=` and `loading=` (verified via grep)
- [x] JSON-LD parses as valid JSON on `/`, `/perfect-human/`, `/mono-no-aware/`
- [x] `/perfect-human/` (CreativeWork) still emits `author`; `/` (ProfilePage) and `/mono-no-aware/` (ExhibitionEvent) don't
- [x] All four shortened titles render at ≤52 chars in `_site/*/index.html`
- [x] Converted images (PNG→JPG) open in `_site/` and HTML references resolve
- [x] `/frames/paris-texas/` preserves all 45 PNG filenames
- [x] CSS-referenced backgrounds in `/img/background/` remain PNG

https://claude.ai/code/session_01L1AKBJSBKXWRKWNKj9PG3R