### PR TITLE
Fix ProfilePage JSON-LD mainEntity + rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lilanyang.studio
 
-Source for [lilanyang.studio](https://lilanyang.studio) — Lilan Yang's moving-image and installation portfolio. Built with [Eleventy](https://www.11ty.dev/) and deployed to GitHub Pages (with a Netlify mirror).
+Source for [lilanyang.studio](https://lilanyang.studio) — Lilan Yang's moving-image and installation portfolio. Built with [Eleventy](https://www.11ty.dev/) and deployed to GitHub Pages.
 
 ## Local development
 
@@ -70,7 +70,4 @@ Eleventy writes `src/foo.html` to `_site/foo/index.html`. An `afterBuild` hook i
 
 ## Deployment
 
-- **GitHub Pages (lilanyang.studio):** pushes to `master` or `develop` trigger `.github/workflows/deploy.yml`, which builds the site and publishes `_site/` via `actions/deploy-pages`.
-- **Netlify mirror (lilanyang.netlify.app):** set a repo secret `NETLIFY_BUILD_HOOK` to Netlify's build-hook URL. The same workflow fires it after the Pages build. If the secret is unset the step logs a skip and the Pages deploy still succeeds.
-
-The custom domain is pinned via the `CNAME` file at the repo root.
+Pushes to `master` or `develop` trigger `.github/workflows/deploy.yml`, which builds the site and publishes `_site/` to GitHub Pages via `actions/deploy-pages`. The custom domain (`lilanyang.studio`) is pinned via the `CNAME` file at the repo root.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,76 @@
-# belphe13.github.io
+# lilanyang.studio
 
-This site is built with [Eleventy](https://www.11ty.dev/).
+Source for [lilanyang.studio](https://lilanyang.studio) — Lilan Yang's moving-image and installation portfolio. Built with [Eleventy](https://www.11ty.dev/) and deployed to GitHub Pages (with a Netlify mirror).
 
-## Development
+## Local development
 
-1. Install dependencies:
-   ```
-   npm install
-   ```
-2. Build the site:
-   ```
-   npm run build
-   ```
-   The generated site will be in the `_site` directory.
+```bash
+npm install
+npm start          # eleventy --serve, live reload on http://localhost:8080
+npm run build      # one-shot build into _site/
+```
 
-All HTML files live in the `src/` directory and share a common layout with global navigation and scripts. Static assets such as CSS and JavaScript are copied to the output unchanged.
+Requires Node 20+.
+
+## Repo layout
+
+```
+src/
+  _includes/
+    layout.njk        # base template: <head>, OG/Twitter tags, JSON-LD, nav
+    nav.njk           # global top navigation
+  *.html              # one file per page (Liquid frontmatter + HTML body)
+  sitemap.njk         # auto-generated sitemap.xml
+  robots.njk          # auto-generated robots.txt
+  llms.njk            # auto-generated llms.txt for AI crawlers
+css/   js/   img/   frames/   icon/   pdf/   kml/   favicon.ico
+                        # passthrough-copied to _site/ unchanged
+.eleventy.js          # config + the alias post-processor (see below)
+.github/workflows/deploy.yml
+```
+
+## Adding or editing a page
+
+Every page in `src/*.html` starts with Liquid frontmatter that `layout.njk` consumes. Minimal version:
+
+```yaml
+---
+layout: layout.njk
+title: "Page Title — Lilan Yang"
+description: "One-sentence summary used for <meta description>, OG, and JSON-LD."
+---
+```
+
+Full reference (all optional except `layout` and `title`):
+
+| Key              | Purpose |
+|------------------|---------|
+| `description`    | `<meta name="description">`, `og:description`, `twitter:description`, JSON-LD `description`. Falls back to site default. |
+| `keywords`       | `<meta name="keywords">`. |
+| `schema_type`    | JSON-LD `@type`. Defaults to `WebPage`. Use `CreativeWork` (or `VisualArtwork`, `Movie`, etc.) for artworks, `ExhibitionEvent` for shows, `ProfilePage`/`AboutPage` for bio pages. Only `CreativeWork` and its subtypes emit `author`/`creator`/`publisher` — this is intentional and keeps Google Search Console's rich-result validator quiet. |
+| `genre`, `artMedium`, `artform`, `date_published` | Extra JSON-LD fields for `CreativeWork`. |
+| `og_image`       | Path to the social share image. Defaults to `/img/index/ecfc.jpg`. |
+| `og_type`        | OG type. Defaults to `website`. |
+| `body_id`        | Sets `<body id="...">` for page-scoped CSS. |
+| `styles`         | List of extra stylesheets to load after `nav.css`. |
+| `scripts`        | List of extra scripts to load in `<head>`. |
+| `hide_nav`       | Set `true` to skip the global nav include. |
+
+## Images
+
+- Originals live under `img/` and `frames/` and are copied straight to `_site/`.
+- Every `<img>` tag should carry `alt=""`, `loading="lazy"`, and `decoding="async"`. The first (LCP) image on a page should use `loading="eager" fetchpriority="high"` instead.
+- `img/background/` and `img/film/` are referenced from CSS and JS — don't rename files in those folders.
+- `frames/paris-texas/` holds a JS-loaded PNG sequence; keep filenames stable.
+- When adding new photography, re-encode to JPG at ~q85 progressive and resize so the longest side ≤ 2000 px before committing — large originals bloat the repo and hurt mobile load times.
+
+## URL routing
+
+Eleventy writes `src/foo.html` to `_site/foo/index.html`. An `afterBuild` hook in `.eleventy.js` also copies each `foo/index.html` to `_site/foo.html`, so both `/foo/` and `/foo.html` resolve to the same content. Canonical links point to the trailing-slash form.
 
 ## Deployment
 
-- **GitHub Pages (lilanyang.studio):** Pushing to `develop` or `master` runs the `Deploy Eleventy to GitHub Pages` workflow, which builds the site and publishes `_site` to Pages.
-- **Netlify (lilanyang.netlify.app):** Add a repository secret named `NETLIFY_BUILD_HOOK` with your site’s build hook URL. The workflow will trigger it on each push to `develop` or `master` after the build completes. If the secret is unset, the workflow will skip the Netlify trigger while still completing the GitHub Pages deploy.
+- **GitHub Pages (lilanyang.studio):** pushes to `master` or `develop` trigger `.github/workflows/deploy.yml`, which builds the site and publishes `_site/` via `actions/deploy-pages`.
+- **Netlify mirror (lilanyang.netlify.app):** set a repo secret `NETLIFY_BUILD_HOOK` to Netlify's build-hook URL. The same workflow fires it after the Pages build. If the secret is unset the step logs a skip and the Pages deploy still succeeds.
+
+The custom domain is pinned via the `CNAME` file at the repo root.

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -152,7 +152,19 @@
       "@type": "WebSite",
       "name": "{{ siteName }}",
       "url": "{{ siteUrl }}"
-    }{% if isCreativeWork %},
+    }{% if pageSchemaType == 'ProfilePage' %},
+    "mainEntity": {
+      "@type": "Person",
+      "name": "Lilan Yang",
+      "alternateName": "Lilan Yang Studio",
+      "url": "{{ siteUrl }}",
+      "image": "{{ pageImageAbs }}",
+      "jobTitle": "Artist and Filmmaker",
+      "description": {{ cleanDescription | dump | safe }},
+      "sameAs": [
+        "https://www.instagram.com/lilanyang.studio/"
+      ]
+    }{% endif %}{% if isCreativeWork %},
     "author": {
       "@type": "Person",
       "name": "Lilan Yang",


### PR DESCRIPTION
## Summary

- **`e9abbae` JSON-LD fix** — Google Search Console flagged "Missing field 'mainEntity'" on the homepage. `ProfilePage` rich results require a `mainEntity` pointing at the Person (or Organization) the page describes. Emit a Person `mainEntity` block in `layout.njk` when `schema_type == "ProfilePage"`; other types are unchanged.
- **`e639921` + `0742ff0` README rewrite** — replace the minimal README with a practical reference: local dev commands, `src/` layout, a table of every recognized frontmatter key, image conventions (alt/lazy/decoding, LCP hint, do-not-rename folders, q85 ≤2000 px for new assets), the `afterBuild` alias behavior, and the GitHub Pages deploy flow. Netlify mirror section removed since the mirror no longer exists.

## Test plan

- [x] `npm run build` — 31 files written, no template errors
- [x] JSON-LD parses as valid JSON on `/`, `/perfect-human/`, `/mono-no-aware/`
- [x] `/` (ProfilePage) now emits `mainEntity` with Person data
- [x] `/perfect-human/` (CreativeWork) and `/mono-no-aware/` (ExhibitionEvent) do NOT emit `mainEntity` (not valid for those types)
- [ ] After merge: hit "Validate fix" in Search Console to revalidate the ProfilePage item

https://claude.ai/code/session_01L1AKBJSBKXWRKWNKj9PG3R

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1AKBJSBKXWRKWNKj9PG3R)_